### PR TITLE
Add tshadow : Text Shadow option in badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ See the [Component Page](http://louchart-mason.fr/poly-badge)
 	<poly-badge raised="1">Shadow is added</poly-badge>
 	<poly-badge info></poly-badge>
 	<poly-badge color="white" bgc="black">Black & White</poly-badge>
+	<poly-badge tshadow>Text Shadow activate</poly-badge>
+	<poly-badge tshadow="1px 1px black">Text Shadow edit</poly-badge>
 	...
 	```
 
@@ -46,6 +48,7 @@ Attribute | Description
 `error`   | Is an error marker
 `color`   | Set the text color
 `bgc`     | Set the background color
+`tshadow` | Set the text shadow
 
 **There are no required options!**
 

--- a/demo.html
+++ b/demo.html
@@ -183,6 +183,22 @@ limitations under the License.
         color is #0034FF
       </td>
     </tr>
+    <tr>
+      <td>bgc</td>
+      <td>#0034FF</td>
+      <td>the
+        <poly-badge tshadow>background</poly-badge>
+        default text shadow is 1px 1px rgba(200, 200, 200, 0.50)
+      </td>
+    </tr>
+    <tr>
+      <td>bgc</td>
+      <td>#0034FF</td>
+      <td>the
+        <poly-badge tshadow="1px 1px black">background</poly-badge>
+        text shadow is 1px 1px black
+      </td>
+    </tr>
     </tbody>
   </table>
 

--- a/poly-badge.html
+++ b/poly-badge.html
@@ -31,6 +31,8 @@ Little badge element based on Polymer.
     <poly-badge raised="1">Shadow is added</poly-badge>
     <poly-badge info></poly-badge>
     <poly-badge color="white" bgc="black">Black & White</poly-badge>
+    <poly-badge tshadow>Text Shadow</poly-badge>
+    <poly-badge tshadow="1px 1px black">Text Shadow</poly-badge>
 
 @element poly-badge
 @blurb Little badge element based on Polymer.
@@ -62,6 +64,10 @@ Little badge element based on Polymer.
     .wide {
       border-radius: inherit;
       padding: 2px 4px;
+    }
+
+    .tshadow {
+      text-shadow: 1px 1px rgba(200, 200, 200, 0.50);
     }
 
     .info,
@@ -111,6 +117,15 @@ Little badge element based on Polymer.
          * @default 0
          */
         raised: 0,
+
+        /**
+         * Set the Text-shadow hight level
+         * 
+         * @attribute hight
+         * @type integer
+         * @default false
+         */
+        tshadow: false,
 
         /**
          * Set the badge like an info marker. Small font size, white on
@@ -171,7 +186,7 @@ Little badge element based on Polymer.
         _label: 'error && "ERROR" || warning && "WARNING" || info && "INFO"',
         _isMarker: '_label ? true : false',
         _classes: '{wide:wide, rounded:!wide, info:info, warning:warning,\
-          error:error, raised:raised} | tokenList'
+          error:error, raised:raised, tshadow:tshadow} | tokenList'
       },
 
       attached: function () {
@@ -194,6 +209,13 @@ Little badge element based on Polymer.
 
       raisedChanged: function (oldValue, newValue) {
         this.shadowRoot.querySelector('paper-shadow').setZ(newValue);
+      },
+
+      tshadowChanged: function(oldValue, newValue) {
+        if (!this._isMarker) {
+          this.shadowRoot.querySelector('paper-shadow')
+            .style.setProperty('text-shadow', newValue);
+        }
       }
 
     })


### PR DESCRIPTION
## Add Attribute : tshadow in poly-badge.

tshadow is attribute for adding text-shadow in poly-badge.

| Option | Code | Result |
| --- | --- | --- |
| Default | <poly-badge><\poly-badge> | no text-shadow. |
| Classical | <poly-badge tshadow><\poly-badge> | style= "text-shadow: 1px 1px rgba(200, 200, 200, 0.50);" |
| Styling | <poly-badge tshadow="1px 1px black"><\poly-badge> | style= "text-shadow: 1px 1px black" |
